### PR TITLE
sort ensemble files before opening them in score_ensemble_outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `--model-metadata` flag to `earth2mip.inference_medium_range` and
   `earth2mip.inference_ensemble`.
 - Add `metadata` argument to `earth2mip.networks.get_model`.
+- Sort the ensemble files before opening them with `glob` in `earth2mip/score_ensemble_outputs.py`
 
 ### Deprecated
 

--- a/earth2mip/score_ensemble_outputs.py
+++ b/earth2mip/score_ensemble_outputs.py
@@ -42,7 +42,7 @@ def _open(f, domain, chunks={"time": 1}):
 
 def open_ensemble(path, group):
     path = pathlib.Path(path)
-    ensemble_files = list(path.glob("ensemble_out_*.nc"))
+    ensemble_files = sorted(list(path.glob("ensemble_out_*.nc")))
     return xarray.concat([_open(f, group) for f in ensemble_files], dim="ensemble")
 
 


### PR DESCRIPTION
# Earth-2 MIP Pull Request

## Description

In `earth2mip/score_ensemble_outputs.py,` the outputs are opened with 

`ensemble_files = list(path.glob("ensemble_out_*.nc"))`

On my machine, the ensemble files aren't necessarily opened in order with glob.  In a directory where I've saved the output files, I have

```
>>> from glob import glob
>>> glob("ensemble_out_*.nc")
['ensemble_out_51.nc', 'ensemble_out_21.nc', 'ensemble_out_20.nc', 'ensemble_out_19.nc', 'ensemble_out_10.nc', 'ensemble_out_17.nc', 'ensemble_out_6.nc', 'ensemble_out_45.nc', 'ensemble_out_32.nc', 'ensemble_out_5.nc', 'ensemble_out_47.nc', 'ensemble_out_36.nc', 'ensemble_out_28.nc', 'ensemble_out_44.nc', 'ensemble_out_38.nc', 'ensemble_out_7.nc', 'ensemble_out_11.nc', 'ensemble_out_26.nc', 'ensemble_out_14.nc', 'ensemble_out_0.nc', 'ensemble_out_34.nc', 'ensemble_out_3.nc', 'ensemble_out_42.nc', 'ensemble_out_22.nc', 'ensemble_out_13.nc', 'ensemble_out_27.nc', 'ensemble_out_37.nc', 'ensemble_out_33.nc', 'ensemble_out_23.nc', 'ensemble_out_16.nc', 'ensemble_out_25.nc', 'ensemble_out_35.nc', 'ensemble_out_46.nc', 'ensemble_out_1.nc', 'ensemble_out_40.nc', 'ensemble_out_49.nc', 'ensemble_out_4.nc', 'ensemble_out_43.nc', 'ensemble_out_39.nc', 'ensemble_out_12.nc', 'ensemble_out_41.nc', 'ensemble_out_30.nc', 'ensemble_out_31.nc', 'ensemble_out_15.nc', 'ensemble_out_50.nc', 'ensemble_out_29.nc', 'ensemble_out_8.nc', 'ensemble_out_2.nc', 'ensemble_out_48.nc', 'ensemble_out_24.nc', 'ensemble_out_18.nc', 'ensemble_out_9.nc']
```

  This PR changes the above line to 

`ensemble_files = sorted(list(path.glob("ensemble_out_*.nc")))`

This ensures that the first file opened is ensemble_out_0.nc.  In turn, this ensures that the 0th ensemble member corresponds to ensemble member 0, which is the control forecast.  Ensemble member 0 is important because that forecast does not have any perturbations applied: it's the control forecast.  This is important for statistics such as `deterministic_mse`

Closes: https://github.com/NVIDIA/earth2mip/issues/7

## Checklist

- [x] I am familiar with the Contributing Guidelines.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The CHANGELOG.md is up to date with these changes.

## Dependencies

No new dependencies needed