### PR TITLE
saving year in name of folder of ensemble output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `--model-metadata` flag to `earth2mip.inference_medium_range` and
   `earth2mip.inference_ensemble`.
 - Add `metadata` argument to `earth2mip.networks.get_model`.
+- Save year in name of the folder of ensemble predictions
 
 ### Deprecated
 

--- a/earth2mip/inference_ensemble.py
+++ b/earth2mip/inference_ensemble.py
@@ -331,7 +331,7 @@ def run_inference(
     date_obj = convert_to_datetime(ds.time[-1])
 
     if config.output_dir:
-        date_str = "{:%Y_%m_%d_%H_%M_%S}".format(date_obj)[5:]
+        date_str = "{:%Y_%m_%d_%H_%M_%S}".format(date_obj)
         name = weather_event.properties.name
         output_path = (
             f"{config.output_dir}/"


### PR DESCRIPTION
# Earth-2 MIP Pull Request

## Description
Currently, the year is not saved in the name of the output folder created by `earth2mip/inference_ensemble.py`.  It would be helpful to save the y ear.  For example, the ensemble predictions initialized at June 20, 2022 and June 20, 2023 data would be saved at the same directory.  Then, the file `ensemble_out_0.nc` will be overwritten.  To solve this problem, I think it would be helpful to save the year in the name of the folder.

To the best of my knowledge, this PR won't break any existing functionality. In `earth2mip`, the path to the ensemble output is passed as an argument to the script.  I don't believe any of the `tests` use the directory name of the ensemble output.

Closes: https://github.com/NVIDIA/earth2mip/issues/18

## Checklist

- [x] I am familiar with the Contributing Guidelines.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The CHANGELOG.md is up to date with these changes.

## Dependencies

None.