### PR TITLE
add back GRF based ensmeble ic method

### DIFF
--- a/earth2mip/ensemble_utils.py
+++ b/earth2mip/ensemble_utils.py
@@ -18,7 +18,6 @@ import torch
 import numpy as np  # noqa
 import h5py  # noqa
 import os  # noqa
-
 from einops import rearrange  # noqa
 from earth2mip import schema  # noqa
 import torch_harmonics as th  # noqa
@@ -28,8 +27,144 @@ from timeit import default_timer  # noqa
 from typing import Union
 
 
+class GaussianRandomFieldS2(torch.nn.Module):
+    def __init__(
+        self,
+        nlat,
+        alpha=2.0,
+        tau=3.0,
+        sigma=None,
+        radius=1.0,
+        grid="equiangular",
+        dtype=torch.float32,
+    ):
+        super().__init__()
+        """A mean-zero Gaussian Random Field on the sphere with Matern covariance:
+        C = sigma^2 (-Lap + tau^2 I)^(-alpha).
+
+        Lap is the Laplacian on the sphere, I the identity operator,
+        and sigma, tau, alpha are scalar parameters.
+
+        Note: C is trace-class on L^2 if and only if alpha > 1.
+
+        Parameters
+        ----------
+        nlat : int
+            Number of latitudinal modes;
+            longitudinal modes are 2*nlat.
+        alpha : float, default is 2
+            Regularity parameter. Larger means smoother.
+        tau : float, default is 3
+            Lenght-scale parameter. Larger means more scales.
+        sigma : float, default is None
+            Scale parameter. Larger means bigger.
+            If None, sigma = tau**(0.5*(2*alpha - 2.0)).
+        radius : float, default is 1
+            Radius of the sphere.
+        grid : string, default is "equiangular"
+            Grid type. Currently supports "equiangular" and
+            "legendre-gauss".
+        dtype : torch.dtype, default is torch.float32
+            Numerical type for the calculations.
+        """
+
+        # Number of latitudinal modes.
+        self.nlat = nlat
+
+        # Default value of sigma if None is given.
+        if sigma is None:
+            assert alpha > 1.0, f"Alpha must be greater than one, got {alpha}."
+            sigma = tau ** (0.5 * (2 * alpha - 2.0))
+
+        # Inverse SHT
+        self.isht = th.InverseRealSHT(
+            self.nlat, 2 * self.nlat, grid=grid, norm="backward"
+        ).to(dtype=dtype)
+
+        # Square root of the eigenvalues of C.
+        sqrt_eig = (
+            torch.tensor([j * (j + 1) for j in range(self.nlat)])
+            .view(self.nlat, 1)
+            .repeat(1, self.nlat + 1)
+        )
+        sqrt_eig = torch.tril(
+            sigma * (((sqrt_eig / radius**2) + tau**2) ** (-alpha / 2.0))
+        )
+        sqrt_eig[0, 0] = 0.0
+        sqrt_eig = sqrt_eig.unsqueeze(0)
+        self.register_buffer("sqrt_eig", sqrt_eig)
+
+        # Save mean and var of the standard Gaussian.
+        # Need these to re-initialize distribution on a new device.
+        mean = torch.tensor([0.0]).to(dtype=dtype)
+        var = torch.tensor([1.0]).to(dtype=dtype)
+        self.register_buffer("mean", mean)
+        self.register_buffer("var", var)
+
+        # Standard normal noise sampler.
+        self.gaussian_noise = torch.distributions.normal.Normal(self.mean, self.var)
+
+    def forward(self, N, xi=None):
+        """Sample random functions from a spherical GRF.
+
+        Parameters
+        ----------
+        N : int
+            Number of functions to sample.
+        xi : torch.Tensor, default is None
+            Noise is a complex tensor of size (N, nlat, nlat+1).
+            If None, new Gaussian noise is sampled.
+            If xi is provided, N is ignored.
+
+        Output
+        -------
+        u : torch.Tensor
+           N random samples from the GRF returned as a
+           tensor of size (N, nlat, 2*nlat) on a equiangular grid.
+        """
+        # Sample Gaussian noise.
+        if xi is None:
+            xi = self.gaussian_noise.sample(
+                torch.Size((N, self.nlat, self.nlat + 1, 2))
+            ).squeeze()
+            xi = torch.view_as_complex(xi)
+
+        # Karhunen-Loeve expansion.
+        u = self.isht(xi * self.sqrt_eig)
+
+        return u
+
+    # Override cuda and to methods so sampler gets initialized with mean
+    # and variance on the correct device.
+    def cuda(self, *args, **kwargs):
+        super().cuda(*args, **kwargs)
+        self.gaussian_noise = torch.distributions.normal.Normal(self.mean, self.var)
+
+        return self
+
+    def to(self, *args, **kwargs):
+        super().to(*args, **kwargs)
+        self.gaussian_noise = torch.distributions.normal.Normal(self.mean, self.var)
+
+        return self
+
+
 def generate_noise_correlated(shape, *, reddening, device, noise_amplitude):
     return noise_amplitude * brown_noise(shape, reddening).to(device)
+
+
+def generate_noise_grf(shape, grid, alpha, sigma, tau):
+    sampler = GaussianRandomFieldS2(nlat=720, alpha=alpha, tau=tau, sigma=sigma)
+    sample_noise = sampler(shape[0] * shape[1] * shape[2]).reshape(
+        shape[0], shape[1], shape[2], 720, 1440
+    )
+    if grid == schema.Grid.grid_721x1440:
+        noise = torch.zeros(shape)
+        noise[:, :, :, :-1, :] = sample_noise
+        noise[:, :, :, -1:, :] = noise[:, :, :, -2:-1, :]
+    else:
+        noise = sample_noise
+    return noise
 
 
 def brown_noise(shape, reddening=2):

--- a/earth2mip/inference_ensemble.py
+++ b/earth2mip/inference_ensemble.py
@@ -39,6 +39,7 @@ from earth2mip import initial_conditions, time_loop
 from earth2mip.ensemble_utils import (
     generate_noise_correlated,
     generate_bred_vector,
+    generate_noise_grf,
 )
 from earth2mip.netcdf import finalize_netcdf, initialize_netcdf, update_netcdf
 from earth2mip.networks import get_model, Inference
@@ -240,6 +241,14 @@ def get_initializer(
                 device=device,
                 noise_amplitude=config.noise_amplitude,
             )
+        elif config.perturbation_strategy == PerturbationStrategy.spherical_grf:
+            noise = generate_noise_grf(
+                shape,
+                model.grid,
+                sigma=config.grf_noise_sigma,
+                alpha=config.grf_noise_alpha,
+                tau=config.grf_noise_tau,
+            ).to(device)
         elif config.perturbation_strategy == PerturbationStrategy.bred_vector:
             noise = generate_bred_vector(
                 x,

--- a/earth2mip/schema.py
+++ b/earth2mip/schema.py
@@ -316,6 +316,7 @@ class PerturbationStrategy(Enum):
     correlated = "correlated"
     gaussian = "gaussian"
     bred_vector = "bred_vector"
+    spherical_grf = "spherical_grf"
 
 
 class EnsembleRun(pydantic.BaseModel):
@@ -338,6 +339,9 @@ class EnsembleRun(pydantic.BaseModel):
         output_dir (optional): The directory to save the output files in (alternative to `output_path`).
         output_path (optional): The path to the output file (alternative to `output_dir`).
         restart_frequency: if provided save at end and at the specified frequency. 0 = only save at end.
+        grf_noise_alpha: tuning parameter of the Gaussian random field, see ensemble_utils.generate_noise_grf for details
+        grf_noise_sigma: tuning parameter of the Gaussian random field, see ensemble_utils.generate_noise_grf for details
+        grf_noise_tau: tuning parameter of the Gaussian random field, see ensemble_utils.generate_noise_grf for details
 
     """  # noqa
 
@@ -360,6 +364,9 @@ class EnsembleRun(pydantic.BaseModel):
     output_dir: Optional[str] = None
     output_path: Optional[str] = None
     restart_frequency: Optional[int] = None
+    grf_noise_alpha: float = 2.0
+    grf_noise_sigma: float = 5.0
+    grf_noise_tau: float = 2.0
 
     def get_weather_event(self) -> weather_events.WeatherEvent:
         if self.forecast_name:


### PR DESCRIPTION
# Earth-2 MIP Pull Request

## Description
I am adding back the `spherical_grf` ensemble IC method that was removed before OSS, as I was waiting for approval from the developer (Nikola K.) before sharing.

Closes: https://github.com/NVIDIA/earth2mip/issues/47

## Checklist

- [x] I am familiar with the Contributing Guidelines.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The CHANGELOG.md is up to date with these changes.
- [x] An [issue](https://github.com/NVIDIA/earth2mip/issues) is linked to this pull request.
