### PR TITLE
fix a bug from PR64, channel_set --> in_channels

### DIFF
--- a/earth2mip/inference_ensemble.py
+++ b/earth2mip/inference_ensemble.py
@@ -260,7 +260,7 @@ def get_initializer(
         if config.perturbation_channels is None:
             x += noise * scale[:, None, None]
         else:
-            channel_list = model.channel_set.list_channels()
+            channel_list = model.in_channel_names
             indices = torch.tensor(
                 [
                     channel_list.index(channel)


### PR DESCRIPTION
# Earth-2 MIP Pull Request
## Description
channel_set remind in the specific variable perturbation call in inference_ensemble.py 
## Checklist

- [x] I am familiar with the Contributing Guidelines.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The CHANGELOG.md is up to date with these changes.
- [x] An [issue](https://github.com/NVIDIA/earth2mip/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->