### PR TITLE
fixing pangu bugs, device in timeloop and missing channels in scale

### DIFF
--- a/earth2mip/inference_ensemble.py
+++ b/earth2mip/inference_ensemble.py
@@ -252,10 +252,13 @@ def get_initializer(
         if rank == 0 and batch_id == 0:  # first ens-member is deterministic
             noise[0, :, :, :, :] = 0
 
-        scale = torch.tensor(
-            [channel_stds[channel] for channel in model.in_channel_names],
-            device=x.device,
-        )
+        scale = []
+        for i, channel in enumerate(model.in_channel_names):
+            if channel in channel_stds:
+                scale.append(channel_stds[channel])
+            else:
+                scale.append(0)
+        scale = torch.tensor(scale, device=x.device)
 
         if config.perturbation_channels is None:
             x += noise * scale[:, None, None]

--- a/earth2mip/networks/pangu.py
+++ b/earth2mip/networks/pangu.py
@@ -194,6 +194,10 @@ class PanguInference(torch.nn.Module):
     def n_history(self):
         return 0
 
+    @property
+    def device(self) -> torch.device:
+        return "cuda"
+
     def normalize(self, x):
         # No normalization for pangu
         return x

--- a/examples/notebooks/02_model_comparison.ipynb
+++ b/examples/notebooks/02_model_comparison.ipynb
@@ -1,7 +1,6 @@
 {
  "cells": [
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -18,7 +17,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -29,7 +27,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -39,7 +37,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -55,7 +52,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -72,7 +69,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -81,7 +77,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -95,12 +91,11 @@
     "    subprocess.run(['wget', '-nc', '-P', f'{pangu_registry}', 'https://get.ecmwf.int/repository/test-data/ai-models/pangu-weather/pangu_weather_24.onnx'], stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT)\n",
     "    subprocess.run(['wget', '-nc', '-P', f'{pangu_registry}', 'https://get.ecmwf.int/repository/test-data/ai-models/pangu-weather/pangu_weather_6.onnx'], stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT)\n",
     "\n",
-    "with open(os.path.join(pangu_registry, 'metadata.json'), 'w') as outfile:\n",
-    "    json.dump({\"entrypoint\": {\"name\": \"earth2mip.networks.pangu:load\"}}, outfile, indent=2)"
+    "    with open(os.path.join(pangu_registry, 'metadata.json'), 'w') as outfile:\n",
+    "        json.dump({\"entrypoint\": {\"name\": \"earth2mip.networks.pangu:load\"}}, outfile, indent=2)"
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -109,9 +104,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Downloading model checkpoint, this may take a bit\n",
+      "Archive:  /code/earth2-mip/examples/models/dlwp_cubesphere.zip\n",
+      "   creating: /code/earth2-mip/examples/models/dlwp/\n",
+      "  inflating: /code/earth2-mip/examples/models/dlwp/map_CS64_LL721x1440.nc  \n",
+      "  inflating: /code/earth2-mip/examples/models/dlwp/geopotential_rs_cs.nc  \n",
+      "  inflating: /code/earth2-mip/examples/models/dlwp/global_stds.npy  \n",
+      "  inflating: /code/earth2-mip/examples/models/dlwp/dlwp.mdlus  \n",
+      " extracting: /code/earth2-mip/examples/models/dlwp/metadata.json  \n",
+      "  inflating: /code/earth2-mip/examples/models/dlwp/map_LL721x1440_CS64.nc  \n",
+      "  inflating: /code/earth2-mip/examples/models/dlwp/latlon_grid_field_rs_cs.nc  \n",
+      "  inflating: /code/earth2-mip/examples/models/dlwp/land_sea_mask_rs_cs.nc  \n",
+      "  inflating: /code/earth2-mip/examples/models/dlwp/initial_condition_7ch.nc  \n",
+      "  inflating: /code/earth2-mip/examples/models/dlwp/global_means.npy  \n",
+      "  inflating: /code/earth2-mip/examples/models/dlwp/simple_inference.py  \n"
+     ]
+    }
+   ],
    "source": [
     "# Now set up DLWP folder\n",
     "if not os.path.isdir(os.path.join(model_registry, 'dlwp')):\n",
@@ -122,7 +138,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -135,9 +150,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdin",
+     "output_type": "stream",
+     "text": [
+      "Enter in CDS UID (e.g. 123456) 211582\n",
+      "Enter your CDS API key (e.g. 12345678-1234-1234-1234-123456123456) 9a810e70-9f48-49b4-9e1b-e7ae17fe15cc\n"
+     ]
+    }
+   ],
    "source": [
     "# Run this cell and input your credentials in the notebook\n",
     "uid = input(\"Enter in CDS UID (e.g. 123456)\")\n",
@@ -150,7 +174,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -165,9 +188,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "TypeError",
+     "evalue": "Inference.__init__() got an unexpected keyword argument 'channels'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mTypeError\u001b[0m                                 Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[7], line 6\u001b[0m\n\u001b[1;32m      4\u001b[0m \u001b[38;5;66;03m# Load DLWP model from registry\u001b[39;00m\n\u001b[1;32m      5\u001b[0m package \u001b[38;5;241m=\u001b[39m registry\u001b[38;5;241m.\u001b[39mget_model(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mdlwp\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n\u001b[0;32m----> 6\u001b[0m dlwp_inference_model \u001b[38;5;241m=\u001b[39m \u001b[43mdlwp\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mload\u001b[49m\u001b[43m(\u001b[49m\u001b[43mpackage\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m      8\u001b[0m \u001b[38;5;66;03m# Load Pangu model(s) from registry\u001b[39;00m\n\u001b[1;32m      9\u001b[0m package \u001b[38;5;241m=\u001b[39m registry\u001b[38;5;241m.\u001b[39mget_model(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mpangu\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n",
+      "File \u001b[0;32m/usr/local/lib/python3.10/dist-packages/earth2mip/networks/dlwp.py:169\u001b[0m, in \u001b[0;36mload\u001b[0;34m(package, pretrained, device)\u001b[0m\n\u001b[1;32m    167\u001b[0m grid \u001b[38;5;241m=\u001b[39m schema\u001b[38;5;241m.\u001b[39mGrid\u001b[38;5;241m.\u001b[39mgrid_721x1440\n\u001b[1;32m    168\u001b[0m dt \u001b[38;5;241m=\u001b[39m datetime\u001b[38;5;241m.\u001b[39mtimedelta(hours\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m12\u001b[39m)\n\u001b[0;32m--> 169\u001b[0m inference \u001b[38;5;241m=\u001b[39m \u001b[43mnetworks\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mInference\u001b[49m\u001b[43m(\u001b[49m\n\u001b[1;32m    170\u001b[0m \u001b[43m    \u001b[49m\u001b[43mmodel\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    171\u001b[0m \u001b[43m    \u001b[49m\u001b[43mchannels\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;28;43;01mNone\u001b[39;49;00m\u001b[43m,\u001b[49m\n\u001b[1;32m    172\u001b[0m \u001b[43m    \u001b[49m\u001b[43mcenter\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mcenter\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    173\u001b[0m \u001b[43m    \u001b[49m\u001b[43mscale\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mscale\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    174\u001b[0m \u001b[43m    \u001b[49m\u001b[43mgrid\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mgrid\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    175\u001b[0m \u001b[43m    \u001b[49m\u001b[43mchannel_names\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mchannel_names\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    176\u001b[0m \u001b[43m    \u001b[49m\u001b[43mtime_step\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mdt\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    177\u001b[0m \u001b[43m    \u001b[49m\u001b[43mn_history\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;241;43m1\u001b[39;49m\u001b[43m,\u001b[49m\n\u001b[1;32m    178\u001b[0m \u001b[43m\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    179\u001b[0m inference\u001b[38;5;241m.\u001b[39mto(device)\n\u001b[1;32m    180\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m inference\n",
+      "\u001b[0;31mTypeError\u001b[0m: Inference.__init__() got an unexpected keyword argument 'channels'"
+     ]
+    }
+   ],
    "source": [
     "import earth2mip.networks.dlwp as dlwp\n",
     "import earth2mip.networks.pangu as pangu\n",
@@ -182,7 +218,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -210,7 +245,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -250,7 +284,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -285,7 +318,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [


### PR DESCRIPTION
# Earth-2 MIP Pull Request
## Description
two bugs appeared in running pangu:
1. device is missing in time loop 
2. the channel `q1000` in pangu does not have a scale. 

This PR handles these two problem, related to #70 

## Checklist

- [x] I am familiar with the Contributing Guidelines.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The CHANGELOG.md is up to date with these changes.
- [x] An [issue](https://github.com/NVIDIA/earth2mip/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->