### PR TITLE
Fix: Update FCN NGC Model

### DIFF
--- a/earth2mip/model_registry.py
+++ b/earth2mip/model_registry.py
@@ -141,7 +141,7 @@ def FCNPackage(root: str, seperator: str):
     download_ngc_package(
         root=root,
         url="https://api.ngc.nvidia.com/v2/models/nvidia/modulus/modulus_fcn/"
-        + "versions/v0.1/files/fcn.zip",
+        + "versions/v0.2/files/fcn.zip",
         zip_file="fcn.zip",
     )
     return Package(root, seperator)


### PR DESCRIPTION
# Earth-2 MIP Pull Request

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

Updating NGC model for FCN due to updated API in Modulus. Updated checkpoint at 0.2:
https://catalog.ngc.nvidia.com/orgs/nvidia/teams/modulus/models/modulus_fcn/version

I tested the fcn example with Modulus installed from source (0.4.0a0) and it works fine.

Closes: https://github.com/NVIDIA/earth2mip/issues/75

## Checklist

- [x] I am familiar with the Contributing Guidelines.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [ ] The CHANGELOG.md is up to date with these changes.
- [x] An [issue](https://github.com/NVIDIA/earth2mip/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->