### PR TITLE
Feat: Adding NGC downloading of diagnostic models

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,8 +132,8 @@ table below.
 | graphcast |  Graphcast, 37 levels, 0.25 deg | Graph neural network | global weather |  [Arxiv](https://arxiv.org/abs/2212.12794)  | [github](https://github.com/google-deepmind/graphcast) | 145MB |
 | graphcast_small |  Graphcast, 13 levels, 1 deg | Graph neural network | global weather |  [Arxiv](https://arxiv.org/abs/2212.12794)  | [github](https://github.com/google-deepmind/graphcast) | 144MB |
 | graphcast_operational |  Graphcast, 13 levels, 0.25 deg| Graph neural network | global weather |  [Arxiv](https://arxiv.org/abs/2212.12794)  | [github](https://github.com/google-deepmind/graphcast) | 144MB |
-| precipitation_afno | FourCastNet Precipitation | Adaptive Fourier Neural Operator  | diagnostic | [Arxiv](https://arxiv.org/abs/2202.11214)   | [modulus](https://registry.ngc.nvidia.com/orgs/nvstaging/teams/simnet/models/modulus_diagnostics) | 300Mb |
-| climatenet | ClimateNet Segmentation Model | Convolutional Neural Network | diagnostic | [GMD](https://doi.org/10.5194/gmd-14-107-2021)   | [modulus](https://registry.ngc.nvidia.com/orgs/nvstaging/teams/simnet/models/modulus_diagnostics) | 2Mb |
+| precipitation_afno | FourCastNet Precipitation | Adaptive Fourier Neural Operator  | diagnostic | [Arxiv](https://arxiv.org/abs/2202.11214)   | [modulus](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/modulus/models/modulus_diagnostics) | 300Mb |
+| climatenet | ClimateNet Segmentation Model | Convolutional Neural Network | diagnostic | [GMD](https://doi.org/10.5194/gmd-14-107-2021)   | [modulus](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/modulus/models/modulus_diagnostics) | 2Mb |
 <!-- markdownlint-enable -->
 
 \* = coming soon

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ table below.
 | ID | Model | Architecture | Type | Reference | Source | Size |
 |:-----:|:-----:|:-------------------------------------------:|:--------------:|:---------:|:-------:|:---:|
 | fcn | FourCastNet | Adaptive Fourier Neural Operator  | global weather | [Arxiv](https://arxiv.org/abs/2202.11214)   | [modulus](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/modulus/models/modulus_fcn) | 300Mb |
-| dlwp |  Deep Learning Weather Prediction  |  Convolution Encoder-Decoder | global weather |   [AGU](https://doi.org/10.1029/2020MS002109)   | [modulus](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/modulus/models/modulus_dlwp_cubesphere) |  50Mb |
+| dlwp |  Deep Learning Weather Prediction  |  Convolutional Encoder-Decoder | global weather |   [AGU](https://doi.org/10.1029/2020MS002109)   | [modulus](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/modulus/models/modulus_dlwp_cubesphere) |  50Mb |
 | pangu | Pangu Weather (Hierarchical 6 + 24 hr)  |  Vision Transformer | global weather |  [Nature](https://doi.org/10.1038/s41586-023-06185-3) | onnx | 2Gb |
 | pangu_6 | Pangu Weather 6hr Model  |  Vision Transformer | global weather |  [Nature](https://doi.org/10.1038/s41586-023-06185-3) | onnx | 1Gb |
 | pangu_24 | Pangu Weather 24hr Model |  Vision Transformer | global weather |  [Nature](https://doi.org/10.1038/s41586-023-06185-3) | onnx | 1Gb |
@@ -132,6 +132,8 @@ table below.
 | graphcast |  Graphcast, 37 levels, 0.25 deg | Graph neural network | global weather |  [Arxiv](https://arxiv.org/abs/2212.12794)  | [github](https://github.com/google-deepmind/graphcast) | 145MB |
 | graphcast_small |  Graphcast, 13 levels, 1 deg | Graph neural network | global weather |  [Arxiv](https://arxiv.org/abs/2212.12794)  | [github](https://github.com/google-deepmind/graphcast) | 144MB |
 | graphcast_operational |  Graphcast, 13 levels, 0.25 deg| Graph neural network | global weather |  [Arxiv](https://arxiv.org/abs/2212.12794)  | [github](https://github.com/google-deepmind/graphcast) | 144MB |
+| precipitation_afno | FourCastNet Precipitation | Adaptive Fourier Neural Operator  | diagnostic | [Arxiv](https://arxiv.org/abs/2202.11214)   | [modulus](https://registry.ngc.nvidia.com/orgs/nvstaging/teams/simnet/models/modulus_diagnostics) | 300Mb |
+| climatenet | ClimateNet Segmentation Model | Convolutional Neural Network | diagnostic | [GMD](https://doi.org/10.5194/gmd-14-107-2021)   | [modulus](https://registry.ngc.nvidia.com/orgs/nvstaging/teams/simnet/models/modulus_diagnostics) | 2Mb |
 <!-- markdownlint-enable -->
 
 \* = coming soon

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -39,6 +39,7 @@ author = "NVIDIA"
 
 extensions = ["sphinx.ext.autodoc", "sphinx.ext.napoleon"]
 
+source_suffix = [".rst", ".md"]
 templates_path = ["_templates"]
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 

--- a/docs/diagnostic.md
+++ b/docs/diagnostic.md
@@ -1,0 +1,77 @@
+# Diagnostics
+
+Models provided in Earth-2 MIP can be classed by one characteristic: those that perform time-integration and those that do not.
+Diagnostic models are a class of models that are intended to transform a set of outputs from a weather/climate model into other quantities of interest.
+Functionally diagnostics are :py:class:`earth2mip.geo_operator.GeoOperator`, models can be viewed as post-processers in the inference process.
+Earth-2 MIP presently provides several built-in diagnostics.
+Those that require a model package files are hosted on [NVIDIA's model registry](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/modulus/models/modulus_diagnostics).
+
+## Using Diagnostic Models
+
+To load / instantiate a diagnostic model, there are two API provided as part of :py:class:`earth2mip.diagnostic.base.DiagnosticBase`. The `load_package` can be called first to create a built in model package, alternatively users can manually create this package for custom registry set ups.
+By default diagnostics with checkpoints will have their model package files stored in `${MODEL_REGISTRY}/diagnostics`.
+The `load_diagnostic` function can then be used to instantiate the diagnostic model.
+
+Diagnostics are integrated into Earth-2 MIP workflows by wrapping a model time loop (iterator).
+The diagnostic :py:class:`earth2mip.diagnostic.DiagnosticTimeLoop` is a class that can be used to attach diagnostic models onto existing Earth-2 MIP workflows.
+This iterator will pull data from the provided weather model time loop, feed this output data through each diagnostic model provided and concatenating the outputs together.
+
+The following demonstrates how to use the diagnostic time loop:
+```python
+from earth2mip.diagnostic import  DiagnosticTimeLoop
+
+# Instantiate weather model
+model = get_model(model_name, device=device)
+
+# Instantiate diagnostic model
+package = DiagnosticModel.load_package()
+diagnostic = DiagnosticModel.load_diagnostic(package)
+
+# Create diagnostic time loop to attach diagnostic models
+model_diagnostic = DiagnosticTimeLoop(diagnostics=[diagnostic], model=model)
+```
+
+## Custom Diagnostics
+
+Adding a custom diagnostic is simple so long as one meets the functional requirements of :py:class:`earth2mip.diagnostic.base.DiagnosticBase` and :py:class:`earth2mip.geo_operator.GeoOperator`.
+The following provides a simple demonstration of how to create a custom diagnostic that just transforms surface temperature from Kelvin to Celcius.
+
+```python
+class Kelvin2Celcius(DiagnosticBase):
+    def __init__(self, grid: grid.LatLonGrid):
+        super().__init__()
+        self.grid = grid
+
+    @property
+    def in_channel_names(self) -> list[str]:
+        return ['t2m']
+
+    @property
+    def out_channel_names(self) -> list[str]:
+        return ['t2m_c']
+
+    @property
+    def in_grid(self) -> grid.LatLonGrid:
+        return self.grid
+
+    @property
+    def out_grid(self) -> grid.LatLonGrid:
+        return self.grid
+
+    def __call__(self, x: torch.Tensor) -> torch.Tensor:
+        return x - 273.15
+
+    @classmethod
+    def load_diagnostic(cls):
+        pass
+
+    @classmethod
+    def load_diagnostic(
+        cls, package: Optional[Package], grid: grid.LatLonGrid
+    ):
+        return cls(grid)
+```
+
+## Known Limitations
+
+- Diagnostics used must operate on grids consistent with the weather model it is attached to.

--- a/docs/diagnostic.md
+++ b/docs/diagnostic.md
@@ -1,7 +1,8 @@
 # Diagnostics
 
-One way to class AI models in Earth-2 MIP is by those that perform time-integration and those that do not.
-Diagnostic models are a class of models that are intended to transform a set of outputs from a weather/climate model into other quantities of interest.
+The term diagnostic model refers here to models that do not make a timestep predictions,
+but simply predict some new quantities from existing ones at the same time.
+By combining a diagnostic and a forecast (prognostic) model we can forecast additional variables without training the latter.
 Functionally diagnostics are :py:class:`earth2mip.geo_operator.GeoOperator`, models can be viewed as post-processers in the inference process.
 Earth-2 MIP presently provides several built-in diagnostics.
 Those that require a model package files are hosted on [NVIDIA's model registry](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/modulus/models/modulus_diagnostics).
@@ -9,7 +10,7 @@ Those that require a model package files are hosted on [NVIDIA's model registry]
 ## Motivation
 
 A natural question is: what is the point of developing a diagnostic model over a new weather/climate model that performs time integration?
-Training AI weather models is a very expensive process, requiring a large set of training data and expertise which is not always available.
+Training AI weather models is a very expensive process, typically requiring a large set training data and compute with a team that has deep learning + weather expertise which is not always available.
 The advantage of diagnostic models is that they can be trained invariant of time, on a reduced set of data / variables and produce quantities that are of interest (versus the ones needed to represent the state of the Earth's weather).
 This opens the door to extending existing foundational models to a vast range of
 downstream tasks both in academia and industry.
@@ -83,4 +84,4 @@ class Kelvin2Celcius(DiagnosticBase):
 
 ## Known Limitations
 
-- Diagnostics used must operate on grids consistent with the weather model it is attached to.
+- The diagnostics used must operate on grids and use channels consistent with the weather model it is attached to.

--- a/docs/diagnostic.md
+++ b/docs/diagnostic.md
@@ -1,12 +1,21 @@
 # Diagnostics
 
-Models provided in Earth-2 MIP can be classed by one characteristic: those that perform time-integration and those that do not.
+One way to class AI models in Earth-2 MIP is by those that perform time-integration and those that do not.
 Diagnostic models are a class of models that are intended to transform a set of outputs from a weather/climate model into other quantities of interest.
 Functionally diagnostics are :py:class:`earth2mip.geo_operator.GeoOperator`, models can be viewed as post-processers in the inference process.
 Earth-2 MIP presently provides several built-in diagnostics.
 Those that require a model package files are hosted on [NVIDIA's model registry](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/modulus/models/modulus_diagnostics).
 
-## Using Diagnostic Models
+## Motivation
+
+A natural question is: what is the point of developing a diagnostic model over a new weather/climate model that performs time integration?
+Training AI weather models is a very expensive process, requiring a large set of training data and expertise which is not always available.
+The advantage of diagnostic models is that they can be trained invariant of time, on a reduced set of data / variables and produce quantities that are of interest (versus the ones needed to represent the state of the Earth's weather).
+This opens the door to extending existing foundational models to a vast range of
+downstream tasks both in academia and industry.
+The built in ClimateNet diagnostic is a great example of how a diagnostic can be used to produce a very useful quantity (identification of tropical cyclones). Combined with ensemble inference workflows this can generate probabilistic fields of hurricane trajectories with little effort.
+
+## Using Diagnostics
 
 To load / instantiate a diagnostic model, there are two API provided as part of :py:class:`earth2mip.diagnostic.base.DiagnosticBase`. The `load_package` can be called first to create a built in model package, alternatively users can manually create this package for custom registry set ups.
 By default diagnostics with checkpoints will have their model package files stored in `${MODEL_REGISTRY}/diagnostics`.

--- a/earth2mip/diagnostic/climate_net.py
+++ b/earth2mip/diagnostic/climate_net.py
@@ -544,7 +544,7 @@ class ClimateNet(DiagnosticBase):
         cls, registry: str = os.path.join(config.MODEL_REGISTRY, "diagnostics")
     ) -> Package:
         registry = ModelRegistry(registry)
-        return registry.get_model("climatenet")
+        return registry.get_model("e2mip://climatenet")
 
     @classmethod
     def load_diagnostic(cls, package: Package, device="cuda:0"):

--- a/earth2mip/diagnostic/climate_net.py
+++ b/earth2mip/diagnostic/climate_net.py
@@ -537,7 +537,7 @@ class ClimateNet(DiagnosticBase):
         assert x.ndim == 4
         x = (x - self.in_center) / self.in_scale
         out = self.model(x)
-        return out
+        return torch.softmax(out, 1)  # Softmax channels
 
     @classmethod
     def load_package(

--- a/earth2mip/diagnostic/precipitation_afno.py
+++ b/earth2mip/diagnostic/precipitation_afno.py
@@ -176,7 +176,7 @@ class PrecipitationAFNO(DiagnosticBase):
         cls, registry: str = os.path.join(config.MODEL_REGISTRY, "diagnostics")
     ) -> Package:
         registry = ModelRegistry(registry)
-        return registry.get_model("precipitation")
+        return registry.get_model("e2mip://precipitation_afno")
 
     @classmethod
     def load_diagnostic(cls, package: Package, device="cuda:0"):

--- a/earth2mip/model_registry.py
+++ b/earth2mip/model_registry.py
@@ -124,6 +124,7 @@ class Package:
 def download_ngc_package(root: str, url: str, zip_file: str):
     model_registry = os.path.dirname(root)
     if not os.path.isdir(root):
+        os.makedirs(model_registry, exist_ok=True)  # Make sure registry folder exists
         logger.info("Downloading NGC model checkpoint, this may take a bit")
         urllib.request.urlretrieve(
             url,

--- a/earth2mip/model_registry.py
+++ b/earth2mip/model_registry.py
@@ -87,6 +87,7 @@ import zipfile
 import urllib
 import json
 
+from typing import Literal
 from earth2mip import schema
 from earth2mip import filesystem
 
@@ -167,6 +168,18 @@ def FCNv2Package(root: str, seperator: str):
     return Package(root, seperator)
 
 
+def NGCDiagnosticPackage(
+    root: str, seperator: str, name: Literal["precipitation_afno", "climatenet"]
+):
+    download_ngc_package(
+        root=root,
+        url="https://api.ngc.nvidia.com/v2/models/nvidia/modulus/modulus_diagnostics/"
+        + f"versions/v0.1/files/{name}.zip",
+        zip_file=f"{name}.zip",
+    )
+    return Package(root, seperator)
+
+
 def PanguPackage(root: str, seperator: str):
 
     name = root.split(seperator)[-1]
@@ -235,6 +248,14 @@ class ModelRegistry:
             return DLWPPackage(self.get_path(name), seperator=self.SEPERATOR)
         elif name == "pangu" or name == "pangu_24" or name == "pangu_6":
             return PanguPackage(self.get_path(name), seperator=self.SEPERATOR)
+        elif name == "precipitation_afno":
+            return NGCDiagnosticPackage(
+                self.get_path(name), seperator=self.SEPERATOR, name=name
+            )
+        elif name == "climatenet":
+            return NGCDiagnosticPackage(
+                self.get_path(name), seperator=self.SEPERATOR, name=name
+            )
         elif name.startswith("graphcast"):
             return Package("gs://dm_graphcast", seperator="/")
         else:

--- a/examples/workflows/inference_diagnostic_basic.py
+++ b/examples/workflows/inference_diagnostic_basic.py
@@ -23,7 +23,7 @@ from earth2mip.initial_conditions import cds
 from earth2mip.diagnostic import PrecipitationAFNO, DiagnosticTimeLoop
 
 
-def main(model_name: str = "e2mip://fcnv2_sm"):
+def main(model_name: str = "e2mip://fcn"):
 
     logging.basicConfig(level=logging.INFO)
 
@@ -45,12 +45,13 @@ def main(model_name: str = "e2mip://fcnv2_sm"):
     time = datetime.datetime(2018, 4, 4)
 
     logging.info("Running inference")
-    run_basic_inference(
+    output = run_basic_inference(
         model_diagnostic,
         n=1,
         data_source=data_source,
         time=time,
     )
+    print(output)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Earth-2 MIP Pull Request

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

1. Adding the NGC model registry for diagnostic models. Enable users to auto download diagnostics using the correct e2mip:// url. Its built into the diagnostic load_package functions as the default.
Unlike the other models, all diagnostics are stored in one [model registry](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/modulus/models/modulus_diagnostics) making access generally easier.
2. Added a markdown doc because I hate RST... docs need pandoc anyway for converting the Jupytext.
3. Also a few bug fixes: registry download when folder doesnt exist, softmax climatenet output
4. Tested both precip and Climatenet with auto download

Closes: https://github.com/NVIDIA/earth2mip/issues/90

![test](https://github.com/NVIDIA/earth2mip/assets/5533524/08722907-3d09-454b-958a-b39c70fb5140)

![test (1)](https://github.com/NVIDIA/earth2mip/assets/5533524/2f1de116-8348-4b44-b305-abdcf3f4de0e)

## Checklist

- [x] I am familiar with the Contributing Guidelines.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [ ] The CHANGELOG.md is up to date with these changes.
- [x] An [issue](https://github.com/NVIDIA/earth2mip/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->