### PR TITLE
Read timestep from hdf5 data

### DIFF
--- a/earth2mip/datasets/era5/__init__.py
+++ b/earth2mip/datasets/era5/__init__.py
@@ -15,7 +15,6 @@
 # limitations under the License.
 
 import contextlib
-import datetime
 import glob
 import json
 import os
@@ -34,9 +33,10 @@ __all__ = ["open_34_vars", "open_hdf5"]
 METADATA = pathlib.Path(__file__).parent / "data.json"
 
 
-def open_hdf5(*, path, f=None, metadata, time_step=datetime.timedelta(hours=6)):
+def open_hdf5(*, path, f=None, metadata):
     dims = metadata["dims"]
     h5_path = metadata["h5_path"]
+    time_step = metadata.get("dhours", 6)
 
     ds = xarray.open_dataset(f or path, engine="h5netcdf", phony_dims="sort")
     array = ds[h5_path]

--- a/earth2mip/datasets/era5/__init__.py
+++ b/earth2mip/datasets/era5/__init__.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 import contextlib
+import datetime
 import glob
 import json
 import os
@@ -36,7 +37,8 @@ METADATA = pathlib.Path(__file__).parent / "data.json"
 def open_hdf5(*, path, f=None, metadata):
     dims = metadata["dims"]
     h5_path = metadata["h5_path"]
-    time_step = metadata.get("dhours", 6)
+    time_step_hours = metadata.get("dhours", 6)
+    time_step = datetime.timedelta(hours=time_step_hours)
 
     ds = xarray.open_dataset(f or path, engine="h5netcdf", phony_dims="sort")
     array = ds[h5_path]

--- a/earth2mip/initial_conditions/hdf5.py
+++ b/earth2mip/initial_conditions/hdf5.py
@@ -45,6 +45,14 @@ class DataSource(base.DataSource):
         subdirB/2017.h5
         subdirB/2016.h5
 
+    data.json should have fields
+
+        h5_path - the name of the data within the hdf5 file
+        coords.channel - list of channels
+        coords.lat - list of lats
+        coords.lon - list of lons
+        dhours - timestep in hours (default 1 hour)
+
     """
 
     def __init__(

--- a/earth2mip/initial_conditions/hdf5.py
+++ b/earth2mip/initial_conditions/hdf5.py
@@ -51,7 +51,7 @@ class DataSource(base.DataSource):
         coords.channel - list of channels
         coords.lat - list of lats
         coords.lon - list of lons
-        dhours - timestep in hours (default 1 hour)
+        dhours - timestep in hours (default 6 hours)
 
     """
 


### PR DESCRIPTION
# Earth-2 MIP Pull Request

## Description

Fix bug when reading hdf5 files not sampled at 6 hours.

## Checklist

- [x] I am familiar with the Contributing Guidelines.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The CHANGELOG.md is up to date with these changes.
- [x] An [issue](https://github.com/NVIDIA/earth2mip/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->