### PR TITLE
use device correctly in time_collection

### DIFF
--- a/earth2mip/time_collection.py
+++ b/earth2mip/time_collection.py
@@ -74,8 +74,8 @@ def main(
         config = json.load(f)
 
     DistributedManager.initialize()
-    model = networks.get_model(config["model"])
     dist = DistributedManager()
+    model = networks.get_model(config["model"], device=dist.device)
 
     protocol = config["protocol"]
     lines = protocol["times"][shard::n_shards]


### PR DESCRIPTION
# Earth-2 MIP Pull Request

## Description

All models were loaded on the default device in parallel jobs. not good.

## Checklist

- [x] I am familiar with the Contributing Guidelines.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The CHANGELOG.md is up to date with these changes.
- [x] An [issue](https://github.com/NVIDIA/earth2mip/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->