### PR TITLE
Fix e2mip://graphcast loading bug

### DIFF
--- a/earth2mip/networks/graphcast.py
+++ b/earth2mip/networks/graphcast.py
@@ -619,15 +619,11 @@ def load_stepper(
 def _load_time_loop_from_description(
     package,
     checkpoint_path: str,
-    resolution: float,
+    dataset_path: str,
     device="cuda:0",
 ) -> TimeStepperLoop:
     checkpoint = package.get(os.path.join("params", checkpoint_path))
-    dataset = {
-        0.25: "source-era5_date-2022-01-01_res-0.25_levels-13_steps-04.nc",
-        1.0: "source-era5_date-2022-01-01_res-1.0_levels-13_steps-04.nc",
-    }[resolution]
-    dataset_path = package.get(os.path.join("dataset", dataset))
+    dataset_path = package.get(os.path.join("dataset", dataset_path))
     stats_dir = package.get("stats", recursive=True)
     stepper = load_stepper(checkpoint, dataset_path, stats_dir, device=device)
     return TimeStepperLoop(stepper)
@@ -642,7 +638,7 @@ def load_time_loop(
     return _load_time_loop_from_description(
         package=package,
         checkpoint_path="GraphCast - ERA5 1979-2017 - resolution 0.25 - pressure levels 37 - mesh 2to6 - precipitation input and output.npz",  # noqa
-        resolution=0.25,
+        dataset_path="source-era5_date-2022-01-01_res-0.25_levels-37_steps-04.nc",
         device=device,
     )
 
@@ -655,7 +651,7 @@ def load_time_loop_small(
     return _load_time_loop_from_description(
         package=package,
         checkpoint_path="GraphCast_small - ERA5 1979-2015 - resolution 1.0 - pressure levels 13 - mesh 2to5 - precipitation input and output.npz",  # noqa
-        resolution=1.0,
+        dataset_path="source-era5_date-2022-01-01_res-1.0_levels-13_steps-04.nc",
         device=device,
     )
 
@@ -668,6 +664,6 @@ def load_time_loop_operational(
     return _load_time_loop_from_description(
         package=package,
         checkpoint_path="GraphCast_operational - ERA5-HRES 1979-2021 - resolution 0.25 - pressure levels 13 - mesh 2to6 - precipitation output only.npz",  # noqa
-        resolution=0.25,
+        dataset_path="source-era5_date-2022-01-01_res-0.25_levels-13_steps-04.nc",
         device=device,
     )


### PR DESCRIPTION
Resolves #150

Proof:

```
In [1]: import earth2mip.networks

In [2]: earth2mip.networks.get_model("e2mip://graphcast")
/home/nbrenowitz/.local/lib/python3.10/site-packages/gribapi/__init__.py:23: UserWarning: ecCodes 2.31.0 or higher is recommended. You are running version 2.30.0
  warnings.warn(

Model description:

GraphCast model at 0.25deg resolution, with 37 pressure levels. This model is
trained on ERA5 data from 1979 to 2017, and can be causally evaluated on 2018
and later years. This model takes as inputs `total_precipitation_6hr`. This was
described in the paper
`GraphCast: Learning skillful medium-range global weather forecasting`
(https://arxiv.org/abs/2212.12794).


Model license:

The model weights are licensed under the Creative Commons
Attribution-NonCommercial-ShareAlike 4.0 International (CC BY-NC-SA 4.0). You
may obtain a copy of the License at:
https://creativecommons.org/licenses/by-nc-sa/4.0/.
The weights were trained on ERA5 data, see README for attribution statement.


All Examples:   {'lon': 1440, 'lat': 721, 'level': 37, 'time': 6, 'batch': 1}
Eval Inputs:    {'batch': 1, 'time': 2, 'lat': 721, 'lon': 1440, 'level': 37}
Eval Targets:   {'batch': 1, 'time': 1, 'lat': 721, 'lon': 1440, 'level': 37}
Eval Forcings:  {'batch': 1, 'time': 1, 'lat': 721, 'lon': 1440}
Inputs:   {'batch': 1, 'time': 2, 'lat': 721, 'lon': 1440, 'level': 37}
Targets:  {'batch': 1, 'time': 1, 'lat': 721, 'lon': 1440, 'level': 37}
Forcings: {'batch': 1, 'time': 1, 'lat': 721, 'lon': 1440}
Out[2]: <earth2mip.time_loop.TimeStepperLoop at 0x7f1944bccd60>

In [3]:

In [3]: earth2mip.networks.get_model("e2mip://graphcast_operational")
Model description:

GraphCast model at 0.25deg resolution, with 13 pressure levels. This model is
trained on ERA5 data from 1979 to 2017, and fine-tuned on HRES-fc0 data from
2016 to 2021 and can be causally evaluated on 2022 and later years. This model
does not take `total_precipitation_6hr` as inputs and can make predictions in an
operational setting (i.e., initialised from HRES-fc0).


Model license:

The model weights are licensed under the Creative Commons
Attribution-NonCommercial-ShareAlike 4.0 International (CC BY-NC-SA 4.0). You
may obtain a copy of the License at:
https://creativecommons.org/licenses/by-nc-sa/4.0/.
The weights were trained on ERA5 data, see README for attribution statement.


All Examples:   {'lon': 1440, 'lat': 721, 'level': 13, 'time': 6, 'batch': 1}
Eval Inputs:    {'batch': 1, 'time': 2, 'lat': 721, 'lon': 1440, 'level': 13}
Eval Targets:   {'batch': 1, 'time': 1, 'lat': 721, 'lon': 1440, 'level': 13}
Eval Forcings:  {'batch': 1, 'time': 1, 'lat': 721, 'lon': 1440}
Inputs:   {'batch': 1, 'time': 2, 'lat': 721, 'lon': 1440, 'level': 13}
Targets:  {'batch': 1, 'time': 1, 'lat': 721, 'lon': 1440, 'level': 13}
Forcings: {'batch': 1, 'time': 1, 'lat': 721, 'lon': 1440}
Out[3]: <earth2mip.time_loop.TimeStepperLoop at 0x7f19224addb0>

In [4]: earth2mip.networks.get_model("e2mip://graphcast_small")
Model description:

Low resolution version of the GraphCast model (1deg, smaller mesh), with 37
pressure levels. This model is trained on ERA5 data from 1979 to 2015, and can
be causally evaluated on 2016 and later years. This model takes as inputs
`total_precipitation_6hr`. This model has much lower memory requirements.


Model license:

The model weights are licensed under the Creative Commons
Attribution-NonCommercial-ShareAlike 4.0 International (CC BY-NC-SA 4.0). You
may obtain a copy of the License at:
https://creativecommons.org/licenses/by-nc-sa/4.0/.
The weights were trained on ERA5 data, see README for attribution statement.


All Examples:   {'lon': 360, 'lat': 181, 'level': 13, 'time': 6, 'batch': 1}
Eval Inputs:    {'batch': 1, 'time': 2, 'lat': 181, 'lon': 360, 'level': 13}
Eval Targets:   {'batch': 1, 'time': 1, 'lat': 181, 'lon': 360, 'level': 13}
Eval Forcings:  {'batch': 1, 'time': 1, 'lat': 181, 'lon': 360}
Inputs:   {'batch': 1, 'time': 2, 'lat': 181, 'lon': 360, 'level': 13}
Targets:  {'batch': 1, 'time': 1, 'lat': 181, 'lon': 360, 'level': 13}
Forcings: {'batch': 1, 'time': 1, 'lat': 181, 'lon': 360}
Out[4]: <earth2mip.time_loop.TimeStepperLoop at 0x7f1944b02dd0>
```
## Checklist

- [ ] I am familiar with the Contributing Guidelines.
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The CHANGELOG.md is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/earth2mip/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->