### PR TITLE
fixing problem where initial conditions are reperturbed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0a1] - 2024-xx-xx
+- Changed earth2mip.inference\_ensemble to avoid reperturbing initial condition repeatedly.  this could lead to large initial condition perturbations if many ensemble members are run per rank.
+
 ## [0.2.0a0] - 2024-xx-xx
 
 ### Added

--- a/earth2mip/inference_ensemble.py
+++ b/earth2mip/inference_ensemble.py
@@ -101,7 +101,7 @@ def run_ensembles(
         batch_size = min(batch_size, n_ensemble - batch_id)
 
         x = x.repeat(batch_size, 1, 1, 1, 1)
-        x = perturb(x, rank, batch_id, model.device)
+        x_start = perturb(x, rank, batch_id, model.device)
         # restart_dir = weather_event.properties.restart
 
         # TODO: figure out if needed
@@ -117,7 +117,7 @@ def run_ensembles(
         #         time=time,
         #     )
 
-        iterator = model(initial_time, x)
+        iterator = model(initial_time, x_start)
 
         # Check if stdout is connected to a terminal
         if sys.stderr.isatty() and progress:
@@ -253,7 +253,7 @@ def get_initializer(
         scale = torch.tensor(scale, device=x.device)
 
         if config.perturbation_channels is None:
-            x += noise * scale[:, None, None]
+            return x + noise * scale[:, None, None]
         else:
             channel_list = model.in_channel_names
             indices = torch.tensor(


### PR DESCRIPTION
# Earth-2 MIP Pull Request

## Description
Fixes #164 

This pull request changes `earth2mip/inference_ensemble` to avoid x from getting reperturbed during each loop's rank over ensemble members.  Previously, x would be perturbed, and then the perturbed x would get perturbed again, and then the perturbed x would get perturbed again.  This could make the magnitude of perturbations very large if many ensemble members are run per rank.

This MR prevents x from being overwritten during the loop over ensemble members.
## Checklist

- [ x] I am familiar with the Contributing Guidelines.
- [ ] New or existing tests cover these changes.
- [ x] The documentation is up to date with these changes.
- [ x] The CHANGELOG.md is up to date with these changes.
- [ x] An [issue](https://github.com/NVIDIA/earth2mip/issues) is linked to this pull request.

