### PR TITLE
earth2mip/ensemble_utils.py

### DIFF
--- a/earth2mip/ensemble_utils.py
+++ b/earth2mip/ensemble_utils.py
@@ -157,7 +157,7 @@ def generate_noise_grf(shape, grid, alpha, sigma, tau, device=None):
         shape[0], shape[1], shape[2], 720, 1440
     )
     if grid.shape == (721, 1440):
-        noise = torch.zeros(shape)
+        noise = torch.zeros(shape).to(device)
         noise[:, :, :, :-1, :] = sample_noise
         noise[:, :, :, -1:, :] = noise[:, :, :, -2:-1, :]
     else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,8 @@ pangu = [
     "onnxruntime-gpu>=1.15.1",
 ]
 graphcast = [
-    "jax>=0.4.16",
+    "flax==0.7.3",
+    "jax==0.4.16",
     "graphcast @ https://github.com/deepmind/graphcast/archive/e622a15c1b9742d78f9b662f2af262604d58c204.tar.gz",
     "gcsfs",
 ]


### PR DESCRIPTION
# Earth-2 MIP Pull Request

## Description
Closes #175. Fixed the bug in perturbation_strategy: "spherical_grf". The bug is caused by missing device conversion when the ensemble inference is ran on GPU.

## Checklist
- [ ] I am familiar with the Contributing Guidelines.
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The CHANGELOG.md is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/earth2mip/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->