### PR TITLE
fix time resampling issue in score_ensemble_outputs.py

### DIFF
--- a/earth2mip/score_ensemble_outputs.py
+++ b/earth2mip/score_ensemble_outputs.py
@@ -110,7 +110,7 @@ def main(
 
             if time_averaging_window:
                 verification = verification.resample(time=time_averaging_window).mean(
-                    dim="time", keep_attrs=True, skipna=False, keepdims=True
+                    dim="time", keep_attrs=True, skipna=False
                 )
 
             ensemble_mse = (verification - ensemble_mean) ** 2.0


### PR DESCRIPTION
correct the issue: resample loses the time coordinate information

# Earth-2 MIP Pull Request

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist

- [ ] I am familiar with the Contributing Guidelines.
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The CHANGELOG.md is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/earth2mip/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->